### PR TITLE
option to select initial tab view

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,8 @@ use ratatui::{
 };
 
 use crossterm::event::{
-    Event as CrosstermEvent, KeyEvent, KeyEventKind, MouseButton, MouseEvent, MouseEventKind,
+    Event as CrosstermEvent, KeyEvent, KeyEventKind, MouseButton, MouseEvent,
+    MouseEventKind,
 };
 
 use serde::Deserialize;
@@ -75,7 +76,8 @@ impl Tab {
 
 // Mouse events matching one of the MouseEventKinds within the Rect will
 // perform the Actions.
-pub type MouseArea = (Rect, SmallVec<[MouseEventKind; 4]>, SmallVec<[Action; 4]>);
+pub type MouseArea =
+    (Rect, SmallVec<[MouseEventKind; 4]>, SmallVec<[Action; 4]>);
 
 /// Handles the main UI for the application.
 ///
@@ -124,7 +126,10 @@ impl App {
             ),
             Tab::new(
                 String::from("Recording"),
-                ObjectList::new(ListType::Node(view::NodeType::Recording), None),
+                ObjectList::new(
+                    ListType::Node(view::NodeType::Recording),
+                    None,
+                ),
             ),
             Tab::new(
                 String::from("Output Devices"),
@@ -271,8 +276,9 @@ struct RenderPacer {
 
 impl RenderPacer {
     fn new(fps: Option<f32>) -> Self {
-        let frame_duration =
-            fps.map_or(Default::default(), |fps| Duration::from_secs_f32(1.0 / fps));
+        let frame_duration = fps.map_or(Default::default(), |fps| {
+            Duration::from_secs_f32(1.0 / fps)
+        });
 
         Self {
             frame_duration,
@@ -363,9 +369,12 @@ impl Handle for Action {
                 app.tabs[app.selected_tab_index].list.up(&app.view);
             }
             Action::TabLeft => {
-                app.selected_tab_index = app.selected_tab_index.checked_sub(1).unwrap_or(4)
+                app.selected_tab_index =
+                    app.selected_tab_index.checked_sub(1).unwrap_or(4)
             }
-            Action::TabRight => app.selected_tab_index = (app.selected_tab_index + 1) % 5,
+            Action::TabRight => {
+                app.selected_tab_index = (app.selected_tab_index + 1) % 5
+            }
             Action::OpenDropdown => {
                 app.tabs[app.selected_tab_index]
                     .list
@@ -394,7 +403,9 @@ impl Handle for Action {
                 app.tabs[app.selected_tab_index].list.selected = Some(object_id)
             }
             Action::ToggleMute => {
-                let commands = app.tabs[app.selected_tab_index].list.toggle_mute(&app.view);
+                let commands = app.tabs[app.selected_tab_index]
+                    .list
+                    .toggle_mute(&app.view);
                 for command in commands {
                     let _ = app.tx.send(command);
                 }
@@ -416,7 +427,9 @@ impl Handle for Action {
                 }
             }
             Action::SetDefault => {
-                let commands = app.tabs[app.selected_tab_index].list.set_default(&app.view);
+                let commands = app.tabs[app.selected_tab_index]
+                    .list
+                    .set_default(&app.view);
                 for command in commands {
                     let _ = app.tx.send(command);
                 }
@@ -437,7 +450,9 @@ impl Handle for Action {
 impl Handle for MouseEvent {
     fn handle(self, app: &mut App) -> Result<bool> {
         match self.kind {
-            MouseEventKind::Down(MouseButton::Left) => app.drag_row = Some(self.row),
+            MouseEventKind::Down(MouseButton::Left) => {
+                app.drag_row = Some(self.row)
+            }
             MouseEventKind::Up(MouseButton::Left) => app.drag_row = None,
             _ => {}
         }
@@ -471,7 +486,8 @@ impl Handle for MonitorEvent {
         for command in app.state.update(self) {
             // Filter out capture commands if capture is disabled
             match command {
-                Command::NodeCaptureStart(..) | Command::NodeCaptureStop(..)
+                Command::NodeCaptureStart(..)
+                | Command::NodeCaptureStop(..)
                     if app.config.peaks == Peaks::Off => {}
                 command => {
                     let _ = app.tx.send(command);
@@ -609,8 +625,10 @@ mod tests {
         let x = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);
         let ctrl_x = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
 
-        let keybindings =
-            HashMap::from([(x, Action::SelectTab(2)), (ctrl_x, Action::SelectTab(4))]);
+        let keybindings = HashMap::from([
+            (x, Action::SelectTab(2)),
+            (ctrl_x, Action::SelectTab(4)),
+        ]);
         let config = Config {
             remote: None,
             fps: None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -74,6 +74,25 @@ impl Tab {
     }
 }
 
+#[derive(
+    Deserialize, Default, Debug, Clone, Copy, PartialEq, clap::ValueEnum,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum Tabs {
+    #[default]
+    Playback,
+    Recording,
+    Output,
+    Input,
+    Configuration,
+}
+
+impl Tabs {
+    pub fn index(&self) -> usize {
+        *self as usize
+    }
+}
+
 // Mouse events matching one of the MouseEventKinds within the Rect will
 // perform the Actions.
 pub type MouseArea =

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,8 +16,7 @@ use ratatui::{
 };
 
 use crossterm::event::{
-    Event as CrosstermEvent, KeyEvent, KeyEventKind, MouseButton, MouseEvent,
-    MouseEventKind,
+    Event as CrosstermEvent, KeyEvent, KeyEventKind, MouseButton, MouseEvent, MouseEventKind,
 };
 
 use serde::Deserialize;
@@ -76,8 +75,7 @@ impl Tab {
 
 // Mouse events matching one of the MouseEventKinds within the Rect will
 // perform the Actions.
-pub type MouseArea =
-    (Rect, SmallVec<[MouseEventKind; 4]>, SmallVec<[Action; 4]>);
+pub type MouseArea = (Rect, SmallVec<[MouseEventKind; 4]>, SmallVec<[Action; 4]>);
 
 /// Handles the main UI for the application.
 ///
@@ -126,10 +124,7 @@ impl App {
             ),
             Tab::new(
                 String::from("Recording"),
-                ObjectList::new(
-                    ListType::Node(view::NodeType::Recording),
-                    None,
-                ),
+                ObjectList::new(ListType::Node(view::NodeType::Recording), None),
             ),
             Tab::new(
                 String::from("Output Devices"),
@@ -156,7 +151,7 @@ impl App {
             rx,
             error_message: None,
             tabs,
-            selected_tab_index: 0,
+            selected_tab_index: config.tab.index(),
             mouse_areas: Vec::new(),
             is_ready: false,
             state: State::default(),
@@ -276,9 +271,8 @@ struct RenderPacer {
 
 impl RenderPacer {
     fn new(fps: Option<f32>) -> Self {
-        let frame_duration = fps.map_or(Default::default(), |fps| {
-            Duration::from_secs_f32(1.0 / fps)
-        });
+        let frame_duration =
+            fps.map_or(Default::default(), |fps| Duration::from_secs_f32(1.0 / fps));
 
         Self {
             frame_duration,
@@ -369,12 +363,9 @@ impl Handle for Action {
                 app.tabs[app.selected_tab_index].list.up(&app.view);
             }
             Action::TabLeft => {
-                app.selected_tab_index =
-                    app.selected_tab_index.checked_sub(1).unwrap_or(4)
+                app.selected_tab_index = app.selected_tab_index.checked_sub(1).unwrap_or(4)
             }
-            Action::TabRight => {
-                app.selected_tab_index = (app.selected_tab_index + 1) % 5
-            }
+            Action::TabRight => app.selected_tab_index = (app.selected_tab_index + 1) % 5,
             Action::OpenDropdown => {
                 app.tabs[app.selected_tab_index]
                     .list
@@ -403,9 +394,7 @@ impl Handle for Action {
                 app.tabs[app.selected_tab_index].list.selected = Some(object_id)
             }
             Action::ToggleMute => {
-                let commands = app.tabs[app.selected_tab_index]
-                    .list
-                    .toggle_mute(&app.view);
+                let commands = app.tabs[app.selected_tab_index].list.toggle_mute(&app.view);
                 for command in commands {
                     let _ = app.tx.send(command);
                 }
@@ -427,9 +416,7 @@ impl Handle for Action {
                 }
             }
             Action::SetDefault => {
-                let commands = app.tabs[app.selected_tab_index]
-                    .list
-                    .set_default(&app.view);
+                let commands = app.tabs[app.selected_tab_index].list.set_default(&app.view);
                 for command in commands {
                     let _ = app.tx.send(command);
                 }
@@ -450,9 +437,7 @@ impl Handle for Action {
 impl Handle for MouseEvent {
     fn handle(self, app: &mut App) -> Result<bool> {
         match self.kind {
-            MouseEventKind::Down(MouseButton::Left) => {
-                app.drag_row = Some(self.row)
-            }
+            MouseEventKind::Down(MouseButton::Left) => app.drag_row = Some(self.row),
             MouseEventKind::Up(MouseButton::Left) => app.drag_row = None,
             _ => {}
         }
@@ -486,8 +471,7 @@ impl Handle for MonitorEvent {
         for command in app.state.update(self) {
             // Filter out capture commands if capture is disabled
             match command {
-                Command::NodeCaptureStart(..)
-                | Command::NodeCaptureStop(..)
+                Command::NodeCaptureStart(..) | Command::NodeCaptureStop(..)
                     if app.config.peaks == Peaks::Off => {}
                 command => {
                     let _ = app.tx.send(command);
@@ -607,6 +591,7 @@ mod tests {
             theme: Default::default(),
             keybindings: Default::default(),
             names: Default::default(),
+            tab: Default::default(),
         };
         let mut app = App::new(command_tx, event_rx, config);
 
@@ -624,10 +609,8 @@ mod tests {
         let x = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);
         let ctrl_x = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
 
-        let keybindings = HashMap::from([
-            (x, Action::SelectTab(2)),
-            (ctrl_x, Action::SelectTab(4)),
-        ]);
+        let keybindings =
+            HashMap::from([(x, Action::SelectTab(2)), (ctrl_x, Action::SelectTab(4))]);
         let config = Config {
             remote: None,
             fps: None,
@@ -637,6 +620,7 @@ mod tests {
             theme: Default::default(),
             keybindings,
             names: Default::default(),
+            tab: Default::default(),
         };
         let mut app = App::new(command_tx, event_rx, config);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,7 +58,10 @@ struct ConfigFile {
     keybindings: HashMap<KeyEvent, Action>,
     #[serde(default)]
     names: Names,
-    #[serde(default = "CharSet::defaults", deserialize_with = "CharSet::merge")]
+    #[serde(
+        default = "CharSet::defaults",
+        deserialize_with = "CharSet::merge"
+    )]
     char_sets: HashMap<String, CharSet>,
     #[serde(default = "Theme::defaults", deserialize_with = "Theme::merge")]
     themes: HashMap<String, Theme>,
@@ -246,8 +249,13 @@ impl TryFrom<ConfigFile> for Config {
     type Error = anyhow::Error;
 
     fn try_from(mut config_file: ConfigFile) -> Result<Self, Self::Error> {
-        let Some(char_set) = config_file.char_sets.remove(&config_file.char_set) else {
-            anyhow::bail!("char_set '{}' does not exist", &config_file.char_set);
+        let Some(char_set) =
+            config_file.char_sets.remove(&config_file.char_set)
+        else {
+            anyhow::bail!(
+                "char_set '{}' does not exist",
+                &config_file.char_set
+            );
         };
 
         let Some(theme) = config_file.themes.remove(&config_file.theme) else {
@@ -283,7 +291,10 @@ impl Config {
     }
 
     /// Parse configuration from the file at the supplied path.
-    pub fn try_new(path: Option<&Path>, opt: &Opt) -> Result<Self, anyhow::Error> {
+    pub fn try_new(
+        path: Option<&Path>,
+        opt: &Opt,
+    ) -> Result<Self, anyhow::Error> {
         let mut config_file: ConfigFile = match path {
             Some(path) if path.exists() => {
                 let context = || {
@@ -293,7 +304,8 @@ impl Config {
                     )
                 };
 
-                let toml_str = fs::read_to_string(path).with_context(context)?;
+                let toml_str =
+                    fs::read_to_string(path).with_context(context)?;
 
                 toml::from_str(&toml_str).with_context(context)?
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,9 +19,8 @@ use ratatui::{style::Style, widgets::block::BorderType};
 use serde::Deserialize;
 use toml;
 
-use crate::app::Action;
+use crate::app::{Action, Tabs};
 use crate::opt::Opt;
-use crate::view::NodeType;
 
 #[derive(Debug)]
 pub struct Config {
@@ -33,7 +32,7 @@ pub struct Config {
     pub theme: Theme,
     pub keybindings: HashMap<KeyEvent, Action>,
     pub names: Names,
-    pub tab: NodeType,
+    pub tab: Tabs,
 }
 
 /// Represents a configuration deserialized from a file. This gets baked into a
@@ -65,7 +64,7 @@ struct ConfigFile {
     char_sets: HashMap<String, CharSet>,
     #[serde(default = "Theme::defaults", deserialize_with = "Theme::merge")]
     themes: HashMap<String, Theme>,
-    tab: Option<NodeType>,
+    tab: Option<Tabs>,
 }
 
 // The serde defaults need to be repeated here, which is used to generate a

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ use toml;
 
 use crate::app::Action;
 use crate::opt::Opt;
+use crate::view::NodeType;
 
 #[derive(Debug)]
 pub struct Config {
@@ -32,6 +33,7 @@ pub struct Config {
     pub theme: Theme,
     pub keybindings: HashMap<KeyEvent, Action>,
     pub names: Names,
+    pub tab: NodeType,
 }
 
 /// Represents a configuration deserialized from a file. This gets baked into a
@@ -56,13 +58,11 @@ struct ConfigFile {
     keybindings: HashMap<KeyEvent, Action>,
     #[serde(default)]
     names: Names,
-    #[serde(
-        default = "CharSet::defaults",
-        deserialize_with = "CharSet::merge"
-    )]
+    #[serde(default = "CharSet::defaults", deserialize_with = "CharSet::merge")]
     char_sets: HashMap<String, CharSet>,
     #[serde(default = "Theme::defaults", deserialize_with = "Theme::merge")]
     themes: HashMap<String, Theme>,
+    tab: Option<NodeType>,
 }
 
 // The serde defaults need to be repeated here, which is used to generate a
@@ -80,6 +80,7 @@ impl Default for ConfigFile {
             names: Default::default(),
             char_sets: CharSet::defaults(),
             themes: Theme::defaults(),
+            tab: Default::default(),
         }
     }
 }
@@ -234,6 +235,10 @@ impl ConfigFile {
         if let Some(theme) = &opt.theme {
             self.theme = theme.clone();
         }
+
+        if let Some(tab) = &opt.tab {
+            self.tab = Some(*tab);
+        }
     }
 }
 
@@ -241,13 +246,8 @@ impl TryFrom<ConfigFile> for Config {
     type Error = anyhow::Error;
 
     fn try_from(mut config_file: ConfigFile) -> Result<Self, Self::Error> {
-        let Some(char_set) =
-            config_file.char_sets.remove(&config_file.char_set)
-        else {
-            anyhow::bail!(
-                "char_set '{}' does not exist",
-                &config_file.char_set
-            );
+        let Some(char_set) = config_file.char_sets.remove(&config_file.char_set) else {
+            anyhow::bail!("char_set '{}' does not exist", &config_file.char_set);
         };
 
         let Some(theme) = config_file.themes.remove(&config_file.theme) else {
@@ -263,6 +263,7 @@ impl TryFrom<ConfigFile> for Config {
             theme,
             keybindings: config_file.keybindings,
             names: config_file.names,
+            tab: config_file.tab.unwrap_or_default(),
         })
     }
 }
@@ -282,10 +283,7 @@ impl Config {
     }
 
     /// Parse configuration from the file at the supplied path.
-    pub fn try_new(
-        path: Option<&Path>,
-        opt: &Opt,
-    ) -> Result<Self, anyhow::Error> {
+    pub fn try_new(path: Option<&Path>, opt: &Opt) -> Result<Self, anyhow::Error> {
         let mut config_file: ConfigFile = match path {
             Some(path) if path.exists() => {
                 let context = || {
@@ -295,8 +293,7 @@ impl Config {
                     )
                 };
 
-                let toml_str =
-                    fs::read_to_string(path).with_context(context)?;
+                let toml_str = fs::read_to_string(path).with_context(context)?;
 
                 toml::from_str(&toml_str).with_context(context)?
             }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
+use crate::app::Tabs;
 use crate::config;
-use crate::view::NodeType;
 
 #[derive(Parser)]
 #[clap(name = "wiremix", about = "PipeWire mixer")]
@@ -70,10 +70,10 @@ pub struct Opt {
         value_name = "VIEW",
         value_enum,
         default_value="playback",
-        value_parser = clap::value_parser!(NodeType),
+        value_parser = clap::value_parser!(Tabs),
         help = "Initial tab view"
     )]
-    pub tab: Option<NodeType>,
+    pub tab: Option<Tabs>,
 
     #[cfg(debug_assertions)]
     #[clap(short, long, help = "Dump events without showing interface")]

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -27,7 +27,11 @@ pub struct Opt {
     )]
     pub remote: Option<String>,
 
-    #[clap(short, long, help = "Target frames per second (or 0 for unlimited)")]
+    #[clap(
+        short,
+        long,
+        help = "Target frames per second (or 0 for unlimited)"
+    )]
     pub fps: Option<f32>,
 
     #[clap(

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 use crate::config;
+use crate::view;
 
 #[derive(Parser)]
 #[clap(name = "wiremix", about = "PipeWire mixer")]
@@ -26,11 +27,7 @@ pub struct Opt {
     )]
     pub remote: Option<String>,
 
-    #[clap(
-        short,
-        long,
-        help = "Target frames per second (or 0 for unlimited)"
-    )]
+    #[clap(short, long, help = "Target frames per second (or 0 for unlimited)")]
     pub fps: Option<f32>,
 
     #[clap(
@@ -62,6 +59,10 @@ pub struct Opt {
 
     #[clap(long, conflicts_with = "no_mouse", help = "Enable mouse support")]
     pub mouse: bool,
+
+    /// Initial tab view
+    #[clap(short = 'v', long, value_name = "VIEW", value_enum, default_value="playback", value_parser = clap::value_parser!(view::NodeType))]
+    pub tab: Option<view::NodeType>,
 
     #[cfg(debug_assertions)]
     #[clap(short, long, help = "Dump events without showing interface")]

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 use crate::config;
-use crate::view;
+use crate::view::NodeType;
 
 #[derive(Parser)]
 #[clap(name = "wiremix", about = "PipeWire mixer")]
@@ -64,9 +64,16 @@ pub struct Opt {
     #[clap(long, conflicts_with = "no_mouse", help = "Enable mouse support")]
     pub mouse: bool,
 
-    /// Initial tab view
-    #[clap(short = 'v', long, value_name = "VIEW", value_enum, default_value="playback", value_parser = clap::value_parser!(view::NodeType))]
-    pub tab: Option<view::NodeType>,
+    #[clap(
+        short = 'v',
+        long,
+        value_name = "VIEW",
+        value_enum,
+        default_value="playback",
+        value_parser = clap::value_parser!(NodeType),
+        help = "Initial tab view"
+    )]
+    pub tab: Option<NodeType>,
 
     #[cfg(debug_assertions)]
     #[clap(short, long, help = "Dump events without showing interface")]

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -69,7 +69,6 @@ pub struct Opt {
         long,
         value_name = "VIEW",
         value_enum,
-        default_value="playback",
         value_parser = clap::value_parser!(Tabs),
         help = "Initial tab view"
     )]

--- a/src/view.rs
+++ b/src/view.rs
@@ -3,6 +3,7 @@
 use itertools::Itertools;
 use std::collections::HashMap;
 
+use serde::Deserialize;
 use serde_json::json;
 
 use crate::command::Command;
@@ -107,7 +108,8 @@ pub enum VolumeAdjustment {
     Absolute(f32),
 }
 
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Deserialize, Default, Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
 pub enum NodeType {
     Playback,
     Recording,
@@ -115,6 +117,12 @@ pub enum NodeType {
     Input,
     #[default]
     All,
+}
+
+impl NodeType {
+    pub fn index(&self) -> usize {
+        *self as usize
+    }
 }
 
 #[derive(Default, Debug, Clone, Copy)]
@@ -156,19 +164,16 @@ fn route_targets(
                 if !route.profiles.contains(&profile_index) {
                     return None;
                 }
-                let route_device =
-                    route.devices.iter().find(|route_device| {
-                        profile_devices.contains(route_device)
-                    })?;
+                let route_device = route
+                    .devices
+                    .iter()
+                    .find(|route_device| profile_devices.contains(route_device))?;
                 let title = if route.available {
                     route.description.clone()
                 } else {
                     format!("{} (unavailable)", route.description)
                 };
-                Some((
-                    Target::Route(device.id, route.index, *route_device),
-                    title,
-                ))
+                Some((Target::Route(device.id, route.index, *route_device), title))
             })
             .collect(),
     )
@@ -177,10 +182,7 @@ fn route_targets(
 /// Get the active route for a device and card device.
 /// This is the route on a device Node IF the route's profile matches the
 /// device's current profile. Otherwise, there is no valid route.
-fn active_route(
-    device: &state::Device,
-    card_device: i32,
-) -> Option<&state::Route> {
+fn active_route(device: &state::Device, card_device: i32) -> Option<&state::Route> {
     let profile_index = device.profile_index?;
 
     device
@@ -205,43 +207,38 @@ impl Node {
         let title = names.resolve(state, node)?;
 
         // Nodes can represent either streams or devices.
-        let (volumes, mute, device_info) =
-            if let Some(device_id) = node.device_id {
-                // Nodes for devices should get their volume and mute status
-                // from the associated device's active route which is also used
-                // for changing the volume and mute status.
-                let device = state.devices.get(&device_id)?;
-                let card_device = node.card_profile_device?;
-                if let Some(route) = active_route(device, card_device) {
-                    let route_index = route.index;
-                    (
-                        route.volumes.clone(),
-                        route.mute,
-                        Some((device_id, route_index, card_device)),
-                    )
-                } else {
-                    (node.volumes.as_ref()?.clone(), node.mute?, None)
-                }
+        let (volumes, mute, device_info) = if let Some(device_id) = node.device_id {
+            // Nodes for devices should get their volume and mute status
+            // from the associated device's active route which is also used
+            // for changing the volume and mute status.
+            let device = state.devices.get(&device_id)?;
+            let card_device = node.card_profile_device?;
+            if let Some(route) = active_route(device, card_device) {
+                let route_index = route.index;
+                (
+                    route.volumes.clone(),
+                    route.mute,
+                    Some((device_id, route_index, card_device)),
+                )
             } else {
-                // We can interact with a stream node's volume and mute status
-                // directly.
                 (node.volumes.as_ref()?.clone(), node.mute?, None)
-            };
+            }
+        } else {
+            // We can interact with a stream node's volume and mute status
+            // directly.
+            (node.volumes.as_ref()?.clone(), node.mute?, None)
+        };
 
-        let (routes, target, target_title) = if let Some(device_id) =
-            node.device_id
-        {
+        let (routes, target, target_title) = if let Some(device_id) = node.device_id {
             // Targets for device nodes are routes for the associated device.
             let device = state.devices.get(&device_id)?;
             let card_device = node.card_profile_device?;
 
-            let mut routes: Vec<_> =
-                route_targets(device, &media_class).unwrap_or_default();
+            let mut routes: Vec<_> = route_targets(device, &media_class).unwrap_or_default();
             routes.sort_by(|(_, a), (_, b)| a.cmp(b));
             let routes = routes;
 
-            let (target, target_title) = match active_route(device, card_device)
-            {
+            let (target, target_title) = match active_route(device, card_device) {
                 Some(route) => {
                     let target_title = if route.available {
                         route.description.clone()
@@ -249,11 +246,7 @@ impl Node {
                         format!("{} (unavailable)", route.description)
                     };
                     (
-                        Some(Target::Route(
-                            device.id,
-                            route.index,
-                            card_device,
-                        )),
+                        Some(Target::Route(device.id, route.index, card_device)),
                         target_title,
                     )
                 }
@@ -328,11 +321,7 @@ impl Node {
 }
 
 impl Device {
-    fn from(
-        state: &state::State,
-        device: &state::Device,
-        names: &config::Names,
-    ) -> Option<Device> {
+    fn from(state: &state::State, device: &state::Device, names: &config::Names) -> Option<Device> {
         let id = device.id;
 
         let title = names.resolve(state, device)?;
@@ -414,27 +403,23 @@ impl View {
         let default_sink_name = default_for(state, "default.audio.sink");
         let default_source_name = default_for(state, "default.audio.source");
 
-        let default_sink =
-            default_sink_name.as_ref().and_then(|default_sink_name| {
+        let default_sink = default_sink_name.as_ref().and_then(|default_sink_name| {
+            state
+                .nodes
+                .values()
+                .find(|node| node.name.as_ref() == Some(default_sink_name))
+                .map(|node| Target::Node(node.id))
+        });
+
+        let default_source = default_source_name
+            .as_ref()
+            .and_then(|default_source_name| {
                 state
                     .nodes
                     .values()
-                    .find(|node| node.name.as_ref() == Some(default_sink_name))
+                    .find(|node| node.name.as_ref() == Some(default_source_name))
                     .map(|node| Target::Node(node.id))
             });
-
-        let default_source =
-            default_source_name
-                .as_ref()
-                .and_then(|default_source_name| {
-                    state
-                        .nodes
-                        .values()
-                        .find(|node| {
-                            node.name.as_ref() == Some(default_source_name)
-                        })
-                        .map(|node| Target::Node(node.id))
-                });
 
         let mut sinks: Vec<_> = state
             .nodes
@@ -459,10 +444,7 @@ impl View {
                     Some((Target::Node(node.id), title))
                 } else if node.media_class.as_ref()?.is_sink() {
                     let title = names.resolve(state, node)?;
-                    Some((
-                        Target::Node(node.id),
-                        format!("Monitor of {}", title),
-                    ))
+                    Some((Target::Node(node.id), format!("Monitor of {}", title)))
                 } else {
                     None
                 }
@@ -500,9 +482,7 @@ impl View {
         let mut nodes_recording = Vec::new();
         let mut nodes_output = Vec::new();
         let mut nodes_input = Vec::new();
-        for (id, node) in
-            nodes.iter().sorted_by_key(|(_, node)| node.object_serial)
-        {
+        for (id, node) in nodes.iter().sorted_by_key(|(_, node)| node.object_serial) {
             nodes_all.push(*id);
             if node.media_class.is_sink_input() {
                 nodes_playback.push(*id);
@@ -552,8 +532,7 @@ impl View {
             if let Some(node) = self.nodes.get_mut(&state_node.id) {
                 match &state_node.peaks {
                     Some(peaks) => {
-                        let peaks_ref =
-                            node.peaks.get_or_insert_with(Default::default);
+                        let peaks_ref = node.peaks.get_or_insert_with(Default::default);
                         peaks_ref.resize(peaks.len(), 0.0);
                         peaks_ref.copy_from_slice(peaks);
                     }
@@ -565,11 +544,7 @@ impl View {
 
     /// Returns a command for setting the provided node as the default
     /// source/sink, depending on device_type.
-    pub fn set_default(
-        &self,
-        node_id: ObjectId,
-        device_type: DeviceType,
-    ) -> Option<Command> {
+    pub fn set_default(&self, node_id: ObjectId, device_type: DeviceType) -> Option<Command> {
         let node = self.nodes.get(&node_id)?;
         let key = match device_type {
             DeviceType::Source => "default.configured.audio.source",
@@ -588,11 +563,7 @@ impl View {
 
     /// Returns a command for setting the provided node's target to the
     /// provided target.
-    pub fn set_target(
-        &self,
-        node_id: ObjectId,
-        target: Target,
-    ) -> Vec<Command> {
+    pub fn set_target(&self, node_id: ObjectId, target: Target) -> Vec<Command> {
         let Some(metadata_id) = self.metadata_id else {
             return Vec::new();
         };
@@ -665,11 +636,7 @@ impl View {
     }
 
     /// Returns a command for changing the volume of the provided node.
-    pub fn volume(
-        &self,
-        node_id: ObjectId,
-        adjustment: VolumeAdjustment,
-    ) -> Option<Command> {
+    pub fn volume(&self, node_id: ObjectId, adjustment: VolumeAdjustment) -> Option<Command> {
         let node = self.nodes.get(&node_id)?;
 
         let mut volumes = node.volumes.clone();
@@ -729,11 +696,7 @@ impl View {
     }
 
     /// Returns the next node in the list_type after a provided node.
-    pub fn next_id(
-        &self,
-        list_type: ListType,
-        object_id: Option<ObjectId>,
-    ) -> Option<ObjectId> {
+    pub fn next_id(&self, list_type: ListType, object_id: Option<ObjectId>) -> Option<ObjectId> {
         let objects = self.ids(list_type);
         let next_index = match object_id {
             Some(object_id) => objects
@@ -763,11 +726,7 @@ impl View {
     }
 
     /// Returns the index in the list_type for the provided object.
-    pub fn position(
-        &self,
-        list_type: ListType,
-        object_id: ObjectId,
-    ) -> Option<usize> {
+    pub fn position(&self, list_type: ListType, object_id: ObjectId) -> Option<usize> {
         self.ids(list_type).iter().position(|&id| id == object_id)
     }
 
@@ -777,10 +736,7 @@ impl View {
     }
 
     /// Returns the possible targets for a node.
-    pub fn node_targets(
-        &self,
-        node_id: ObjectId,
-    ) -> Option<(Vec<(Target, String)>, usize)> {
+    pub fn node_targets(&self, node_id: ObjectId) -> Option<(Vec<(Target, String)>, usize)> {
         let node = self.nodes.get(&node_id)?;
 
         // Get the target list appropriate to the node type
@@ -805,9 +761,7 @@ impl View {
         // Sort targets by name
         targets.sort_by(|(_, a), (_, b)| a.cmp(b));
         // If the targets are nodes, add the default node to the top
-        if node.media_class.is_sink_input()
-            || node.media_class.is_source_output()
-        {
+        if node.media_class.is_sink_input() || node.media_class.is_source_output() {
             targets.insert(0, (Target::Default, default_name.clone()));
         };
         let targets = targets;
@@ -827,10 +781,7 @@ impl View {
     }
 
     /// Returns the possible targets for a device.
-    pub fn device_targets(
-        &self,
-        device_id: ObjectId,
-    ) -> Option<(Vec<(Target, String)>, usize)> {
+    pub fn device_targets(&self, device_id: ObjectId) -> Option<(Vec<(Target, String)>, usize)> {
         let device = self.devices.get(&device_id)?;
 
         let targets = device.profiles.clone();

--- a/src/view.rs
+++ b/src/view.rs
@@ -3,7 +3,6 @@
 use itertools::Itertools;
 use std::collections::HashMap;
 
-use serde::Deserialize;
 use serde_json::json;
 
 use crate::command::Command;
@@ -108,10 +107,7 @@ pub enum VolumeAdjustment {
     Absolute(f32),
 }
 
-#[derive(
-    Deserialize, Default, Debug, Clone, Copy, PartialEq, clap::ValueEnum,
-)]
-#[serde(rename_all = "lowercase")]
+#[derive(Default, Debug, Clone, Copy)]
 pub enum NodeType {
     Playback,
     Recording,
@@ -119,12 +115,6 @@ pub enum NodeType {
     Input,
     #[default]
     All,
-}
-
-impl NodeType {
-    pub fn index(&self) -> usize {
-        *self as usize
-    }
 }
 
 #[derive(Default, Debug, Clone, Copy)]


### PR DESCRIPTION
The user may specify which tab is initially displayed when `wiremix` is launched.

```shell
wiremix # default tab is still 'playback'
wiremix -v recording
wiremix --tab input
```

Helpful when launching `wiremix` from a speaker or microphone status bar widget.

Apologies for the auto-formatting changes.