### PR TITLE
Update the installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Issues and pull requests are welcome!
 
 ### Package Managers
 
-* Arch Linux (AUR): Install
-  [wiremix-git](https://aur.archlinux.org/packages/wiremix-git) with your AUR
-  helper. For example, `yay -S wiremix-git`
+* Arch Linux: Install the [official package](https://archlinux.org/packages/extra/x86_64/wiremix/)
+  via `pacman -S wiremix` or `paru -S wiremix-git` for the
+  latest development version from the [AUR](https://aur.archlinux.org/packages/wiremix-git).
 * Nix: `nix run github:tsowell/wiremix` or add wiremix to your configuration
   using the provided [flake.nix](./flake.nix)
 


### PR DESCRIPTION
Thanks for the slick TUI, it's amazing!

I packaged it for Arch btw so it can be installed from the official repos: <https://archlinux.org/packages/extra/x86_64/wiremix/>

This PR updates the README.md about that
