### PR TITLE
nix: avoid unnecessary rebuilds

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -5,13 +5,21 @@
   pipewire,
 }:
 let
+  fs = lib.fileset;
   cargoPackage = (lib.importTOML ./Cargo.toml).package;
 in
 rustPlatform.buildRustPackage {
   pname = cargoPackage.name;
   version = cargoPackage.version;
 
-  src = lib.cleanSource ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      (fs.fileFilter (file: builtins.any file.hasExt [ "rs" ]) ./src)
+      ./Cargo.lock
+      ./Cargo.toml
+    ];
+  };
 
   nativeBuildInputs = [
     pkg-config

--- a/package.nix
+++ b/package.nix
@@ -28,4 +28,11 @@ rustPlatform.buildRustPackage {
   buildInputs = [ pipewire ];
 
   cargoLock.lockFile = ./Cargo.lock;
+
+  # Vendor default configuration for reference or for wrapping
+  # without having to commit the file to a git repository.
+  postInstall = ''
+    mkdir -p $out/share
+    install -Dm755 ${./wiremix.toml} $out/share/wiremix.toml
+  '';
 }


### PR DESCRIPTION
Followup PR to #9, aims to "fix" the inefficient source filter that will still allow for unnecessary rebuilds. [^1] Also installs the default config to `$out/share`, so that wrapping wiremix with `symlinkJoin` or similar to use the default config (if, say, .config is ignored) is possible and easy without having to download it first, and push it to a repo.

[^1]: The input-addressed nature of Nix means that in the current derivation, which points at the repository root as a source, a rebuild will be triggered *regardless of whether the change affects the build output*. For example, a change to the README or simply a typo fix in `package.nix` would cause the Rust program to be rebuild. This is negligible for small, fast builders but for Rust it is quite an annoyance. 