### PR TITLE
fix: include wiremix.toml in nix source files

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -16,6 +16,7 @@ rustPlatform.buildRustPackage {
     root = ./.;
     fileset = fs.unions [
       (fs.fileFilter (file: builtins.any file.hasExt [ "rs" ]) ./src)
+      ./wiremix.toml
       ./Cargo.lock
       ./Cargo.toml
     ];


### PR DESCRIPTION
Due to the tests added at 9fddfa9b90bdd1661c022d62e9f4458a80e927de the nix package fails to build because it doesn't find the wiremix.toml file during the include_str!
Adding the file to the sources fixes this.