### PR TITLE
nix: add `build.rs` to source filter

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -16,6 +16,7 @@ rustPlatform.buildRustPackage {
     root = ./.;
     fileset = fs.unions [
       (fs.fileFilter (file: builtins.any file.hasExt [ "rs" ]) ./src)
+      ./build.rs
       ./wiremix.toml
       ./Cargo.lock
       ./Cargo.toml


### PR DESCRIPTION
Fixes the build failure due to the missing `build.rs` in the filtered source directory. I currently lack the bandwidth to do this, but a Nix build CI might be a nice addition to catch build failures early, as this failure was caught by [my cache CI](https://github.com/NotAShelf/nyxexprs/actions/runs/16093795160/job/45413937192) and I missed the breaking change by a week.