### PR TITLE
fix: show monitor name for HDMI/DP audio endpoints

### DIFF
--- a/src/config/names.rs
+++ b/src/config/names.rs
@@ -16,6 +16,7 @@ impl Names {
 
     pub fn default_endpoint() -> Vec<NameTemplate> {
         vec![
+            "{node:node.nick}".parse().unwrap(),
             "{device:device.nick}".parse().unwrap(),
             "{node:node.description}".parse().unwrap(),
         ]

--- a/src/view.rs
+++ b/src/view.rs
@@ -380,12 +380,11 @@ impl Device {
                             .any(|d| profile_devices.contains(d))
                     })
                     .collect();
-                let monitor_name =
-                    if matching_routes.len() == 1 {
-                        matching_routes[0].product_name.as_deref()
-                    } else {
-                        None
-                    };
+                let monitor_name = if matching_routes.len() == 1 {
+                    matching_routes[0].product_name.as_deref()
+                } else {
+                    None
+                };
                 let title = match (profile.available, monitor_name) {
                     (true, Some(name)) => {
                         format!("{} \u{2014} {}", profile.description, name)

--- a/src/view.rs
+++ b/src/view.rs
@@ -365,10 +365,39 @@ impl Device {
             .profiles
             .values()
             .map(|profile| {
-                let title = if profile.available {
-                    profile.description.clone()
-                } else {
-                    format!("{} (unavailable)", profile.description)
+                let profile_devices: Vec<i32> = profile
+                    .classes
+                    .iter()
+                    .flat_map(|(_, devices)| devices.iter().copied())
+                    .collect();
+                let matching_routes: Vec<_> = device
+                    .enum_routes
+                    .values()
+                    .filter(|route| {
+                        route
+                            .devices
+                            .iter()
+                            .any(|d| profile_devices.contains(d))
+                    })
+                    .collect();
+                let monitor_name =
+                    if matching_routes.len() == 1 {
+                        matching_routes[0].product_name.as_deref()
+                    } else {
+                        None
+                    };
+                let title = match (profile.available, monitor_name) {
+                    (true, Some(name)) => {
+                        format!("{} \u{2014} {}", profile.description, name)
+                    }
+                    (false, Some(name)) => format!(
+                        "{} \u{2014} {} (unavailable)",
+                        profile.description, name
+                    ),
+                    (true, None) => profile.description.clone(),
+                    (false, None) => {
+                        format!("{} (unavailable)", profile.description)
+                    }
                 };
                 (profile.index, title)
             })

--- a/src/view.rs
+++ b/src/view.rs
@@ -402,19 +402,19 @@ impl Device {
             })
             .collect();
         profiles.sort_by_key(|&(index, _)| index);
-        let profiles = profiles
+        let profiles: Vec<(Target, String)> = profiles
             .into_iter()
             .map(|(index, title)| (Target::Profile(object_id, index), title))
             .collect();
 
-        let target_profile = device.profiles.get(&device.profile_index?)?;
-        let target_title = if target_profile.available {
-            target_profile.description.clone()
-        } else {
-            format!("{} (unavailable)", target_profile.description)
-        };
+        let profile_index = device.profile_index?;
+        let target_title = profiles
+            .iter()
+            .find(|(t, _)| *t == Target::Profile(object_id, profile_index))
+            .map(|(_, title)| title.clone())
+            .unwrap_or_default();
 
-        let target = Some(Target::Profile(object_id, device.profile_index?));
+        let target = Some(Target::Profile(object_id, profile_index));
 
         let object_serial = *device.props.object_serial()?;
 

--- a/src/wirehose/device.rs
+++ b/src/wirehose/device.rs
@@ -100,6 +100,7 @@ fn device_enum_route(object_id: ObjectId, param: Object) -> Option<StateEvent> {
     let mut available = None;
     let mut profiles = None;
     let mut devices = None;
+    let mut product_name = None;
 
     for prop in param.properties {
         match prop.key {
@@ -129,6 +130,25 @@ fn device_enum_route(object_id: ObjectId, param: Object) -> Option<StateEvent> {
                     devices = Some(value);
                 }
             }
+            libspa_sys::SPA_PARAM_ROUTE_info => {
+                if let Value::Struct(info_struct) = prop.value {
+                    let skip = match info_struct.first() {
+                        Some(Value::Int(_)) => 1,
+                        _ => 0,
+                    };
+                    let mut iter = info_struct.into_iter().skip(skip);
+                    while let (
+                        Some(Value::String(key)),
+                        Some(Value::String(val)),
+                    ) = (iter.next(), iter.next())
+                    {
+                        if key == "device.product.name" {
+                            product_name = Some(val);
+                            break;
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -140,6 +160,7 @@ fn device_enum_route(object_id: ObjectId, param: Object) -> Option<StateEvent> {
         available: available?,
         profiles: profiles?,
         devices: devices?,
+        product_name,
     })
 }
 

--- a/src/wirehose/event.rs
+++ b/src/wirehose/event.rs
@@ -28,6 +28,7 @@ pub enum StateEvent {
         available: bool,
         profiles: Vec<i32>,
         devices: Vec<i32>,
+        product_name: Option<String>,
     },
     DeviceEnumProfile {
         object_id: ObjectId,

--- a/src/wirehose/state.rs
+++ b/src/wirehose/state.rs
@@ -21,6 +21,7 @@ pub struct EnumRoute {
     pub available: bool,
     pub profiles: Vec<i32>,
     pub devices: Vec<i32>,
+    pub product_name: Option<String>,
 }
 
 #[derive(Debug)]
@@ -162,6 +163,7 @@ impl State {
                 available,
                 profiles,
                 devices,
+                product_name,
             } => {
                 self.device_entry(object_id).enum_routes.insert(
                     index,
@@ -171,6 +173,7 @@ impl State {
                         available,
                         profiles,
                         devices,
+                        product_name,
                     },
                 );
             }

--- a/wiremix.toml
+++ b/wiremix.toml
@@ -166,7 +166,7 @@ keybindings = [
 # Streams in the Playback/Recording tabs
 stream = [ "{node:node.name}: {node:media.name}" ]
 # Endpoints in the Input/Output Devices tabs
-endpoint = [ "{device:device.nick}", "{node:node.description}" ]
+endpoint = [ "{node:node.nick}", "{device:device.nick}", "{node:node.description}" ]
 # Devices in the Configuration tab
 device = [ "{device:device.nick}", "{device:device.description}" ]
 


### PR DESCRIPTION
## Problem
<img width="2006" height="726" alt="image" src="https://github.com/user-attachments/assets/c1916f5d-355c-4685-baae-6e73cbc218fc" />
<img width="802" height="322" alt="image" src="https://github.com/user-attachments/assets/544151e8-c3c7-4d77-ab5d-3f4880202b4d" />

When using NVIDIA GPU audio in **pro-audio mode**, or any HDMI/DP output, all sinks share the same PipeWire *device*. The default endpoint name template resolves `{device:device.nick}` first — which returns the GPU/card name (e.g. `HDA NVidia`) for every output — making multiple HDMI/DP sinks completely indistinguishable in wiremix.

Additionally, the Configuration tab shows generic names for both the selected profile and the profile dropdown, with no indication of which physical monitor each profile corresponds to.

**Reproducing steps:**

1. Have a machine with an NVIDIA GPU and multiple monitors connected via HDMI/DisplayPort
2. Enable pro-audio profile: `pactl set-card-profile alsa_card.pci-0000_01_00.1 pro-audio`
3. Open wiremix → all HDMI/DP sinks appear as `HDA NVidia` in Output Devices tab
4. Switch to the Configuration tab → selected profile shows `Digital Stereo (HDMI 2) Output` and the dropdown lists all profiles without monitor names

**Expected:** each sink, selected profile, and profile dropdown entry shows the name of the connected monitor (e.g. `PA32QCV`, `DELL U2723QE`)

**Actual:** all sinks show `HDA NVidia`; selected profile and dropdown show generic HDMI port numbers only

## Root cause

**Output Devices tab:** PipeWire reads the monitor name from EDID/ELD data and stores it in `node.nick` (e.g. `PA32QCV`, `DELL U2723QE`). The device-level `device.nick` is the GPU name shared by all HDMI outputs on that card. The default endpoint template tried `{device:device.nick}` first — it always succeeds — so `{node:node.description}` was never reached.

**Configuration tab:** Profile descriptions (`Digital Stereo (HDMI) Output`) come from PipeWire and don't include monitor names. The `SPA_PARAM_ROUTE_info` dict on each EnumRoute contains `device.product.name` (the EDID monitor name) but was not being parsed. The selected profile display was also derived independently from the raw profile description, so it missed the enrichment too.

This can be verified:

```
$ aplay -l | grep NVidia
card 0: NVidia [HDA NVidia], device 3: HDMI 0 [DELL U2723QE]
card 0: NVidia [HDA NVidia], device 7: HDMI 1 [PA32QCV]

$ pactl list sinks | grep "node.nick"
  node.nick = "DELL U2723QE"
  node.nick = "PA32QCV"
```

## Fix
<img width="2006" height="364" alt="image" src="https://github.com/user-attachments/assets/b237f8c1-060f-46f2-a952-46ff1745bd32" />
<img width="792" height="282" alt="image" src="https://github.com/user-attachments/assets/572d8b4a-1d6c-46be-bc5a-39556c32e08f" />

**Output Devices tab:** Add `{node:node.nick}` as the first template in `default_endpoint`. When `node.nick` is set (HDMI/DP monitors), it is used. When absent, falls through to `{device:device.nick}` as before.

```diff
 pub fn default_endpoint() -> Vec<NameTemplate> {
     vec![
+        "{node:node.nick}".parse().unwrap(),
         "{device:device.nick}".parse().unwrap(),
         "{node:node.description}".parse().unwrap(),
     ]
 }
```

**Configuration tab:** Parse `SPA_PARAM_ROUTE_info` in `device_enum_route` to extract `device.product.name`. When a profile maps to exactly one route with a known monitor name, append it to the profile description. The selected profile display reuses this enriched title so it stays consistent with the dropdown.

```
Before: Digital Stereo (HDMI 2) Output
After:  Digital Stereo (HDMI 2) Output — PA32QCV
```

Profiles that map to multiple routes (e.g. Pro Audio) or no routes (e.g. Off) are left unchanged.