### PR TITLE
wiremix.toml: fix typo in keybindings comment

### DIFF
--- a/wiremix.toml
+++ b/wiremix.toml
@@ -73,7 +73,7 @@ lazy_capture = false
 #
 # keybindings = [
 #  # Demonstrate modifiers
-#  { key = "End", modifier = "CTRL | ALT", action = "Exit" },
+#  { key = "End", modifiers = "CTRL | ALT", action = "Exit" },
 # ]
 #
 # Each of the available keybinding actions are documented below.


### PR DESCRIPTION
fix typo in code that people will (who me), will copy-paste to config