### PR TITLE
feat: enable set default action on non device nodes

### DIFF
--- a/src/object_list.rs
+++ b/src/object_list.rs
@@ -176,10 +176,12 @@ impl ObjectList {
         if matches!(self.list_kind, ListKind::Device) {
             return;
         }
-        if let (Some(node_id), Some(device_kind)) =
-            (self.selected, self.device_kind)
-        {
-            view.set_default(node_id, device_kind);
+        if let Some(node_id) = self.selected {
+            if let Some(device_kind) = self.device_kind {
+                view.set_default(node_id, device_kind);
+            } else {
+                view.set_target(node_id, view::Target::Default);
+            }
         }
     }
 


### PR DESCRIPTION
This PR extends the existing set-default action to work from node views in addition to device views.

Previously, the shortcut could only be used when selecting a device to set the default input or output device. It can now also be triggered from node lists (playback, recording), allowing users to quickly change input/output device to the default one.