### PR TITLE
Show nick when no routes are available

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -278,7 +278,20 @@ impl Node {
                         target_title,
                     )
                 }
-                None => (None, String::from("No route selected")),
+                None => {
+                    let target_title = if routes.is_empty() {
+                        node.props
+                            .node_nick()
+                            .filter(|s| !s.is_empty())
+                            .cloned()
+                            .unwrap_or_else(|| {
+                                String::from("No routes available")
+                            })
+                    } else {
+                        String::from("No route selected")
+                    };
+                    (None, target_title)
+                }
             };
 
             (Some(routes), target, target_title)


### PR DESCRIPTION
On my laptop, with the Pro Audio configuration, wiremix shows 5 different outputs all named "sof-hda-dsp", with "No route selected". I.e.: they're impossible to tell apart.

Apparently, this is always the case with Pipewire's Pro Audio configuration: each output is its own node, and there are no routes for them.

When no routes are available, show the output's nick instead, which are determined based on the underlying ALSA description. For my same laptop mentioned above, these would show "Pro", "HDMI 1", "HDMI 2", "HDMI 3" and "Pro 31". These names aren't great, but I can tell them apart. Improving the names generated by PipeWire is a separate task which I hope to complete soon, but is merely complementary and non-blocking for this change.