### PR TITLE
Opt wiremix's capture streams out of wireplumber state persistence

### DIFF
--- a/src/wirehose/stream.rs
+++ b/src/wirehose/stream.rs
@@ -98,6 +98,18 @@ pub fn capture_node(
         *pipewire::keys::TARGET_OBJECT => String::from(serial),
         *pipewire::keys::STREAM_MONITOR => "true",
         *pipewire::keys::NODE_NAME => "wiremix-capture",
+        // wireplumber's state-stream.lua persists volume/mute/target to disk
+        // (~/.local/state/wireplumber/stream-properties) for any node whose
+        // media.class matches "Stream/*", which this capture stream does by
+        // default. That's real per-event disk I/O (write+fsync+rename,
+        // debounced but still frequent) for a purely internal metering tap
+        // that has no volume/mute/target of its own worth remembering -
+        // these two properties are wireplumber's own opt-out mechanism
+        // (checked directly in state-stream.lua before any of that work
+        // happens), and eliminate the cost entirely rather than just
+        // reducing how many capture streams exist at once.
+        "state.restore-props" => "false",
+        "state.restore-target" => "false",
     };
     if capture_sink {
         props.insert(*pipewire::keys::STREAM_CAPTURE_SINK, "true");


### PR DESCRIPTION
⚠️ **Full Disclosure:** Drafted with AI assistance (Claude); reviewed by me briefly. I am neither a Rust developer nor pipewire expert. If I should stop making these PRs into your wonderful project, please let me know. ⚠️

That being said, I hope these can be helpful and useful additions that users could appreciate.

---

wireplumber's `state-stream.lua` persists volume/mute/target to disk (`~/.local/state/wireplumber/stream-properties`, write+fsync+rename, debounced) for any node whose `media.class` matches `Stream/*` - which is what a `pw_stream` gets by default when no `media.class` is set, exactly wiremix's capture streams (`wirehose/stream.rs::capture_node`). These streams are purely internal metering taps with no volume/mute/target of their own worth remembering across launches, so every Props update on one is wasted disk I/O and wireplumber policy work.

`state-stream.lua` already supports a per-node opt-out, checked before any of that work happens: `stream_props["state.restore-props"]` and `["state.restore-target"]`. Setting both to `"false"` on the capture stream skips it entirely.

A note on scope, in the interest of not overselling this: I confirmed via `strace` that wireplumber's state-file write path is real and not free, but on investigation the dominant cost on a real system with many concurrent streams turned out to be an unrelated background process (something else entirely was recreating its own stream repeatedly) rather than wiremix's captures specifically. So this is a legitimate, low-risk correctness fix - an internal tap shouldn't be treated like a real user stream - more than a load-bearing performance fix on its own. Still worth doing: it costs nothing for any wiremix build, and removes real per-event disk I/O that has no reason to happen for these streams.

**Tested:**
- `cargo test`: 144/144 passing
- `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo doc` (matching this repo's CI): all clean

---

This feature, together with other experimental changes, is included and should be ready to play with in the [wiremix-extras](https://github.com/HoneyHazard/wiremix-extras) experiment.

