### PR TITLE
Add max_concurrent_captures to cap and rotate simultaneous peak captures

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -214,6 +214,12 @@ pub struct App<'a> {
     capturable_objects: HashSet<ObjectId>,
     /// Objects currently being captured.
     capturing_objects: HashSet<ObjectId>,
+    /// Index into the sorted eligible-objects list where the next capture
+    /// rotation window should start. Only meaningful when
+    /// config.max_concurrent_captures is set.
+    capture_rotation_start: usize,
+    /// When the capture rotation window last advanced.
+    last_capture_rotation: Instant,
 }
 
 macro_rules! current_list {
@@ -261,6 +267,8 @@ impl<'a> App<'a> {
             peak_processor: Arc::new(peak_processor),
             capturable_objects: HashSet::new(),
             capturing_objects: HashSet::new(),
+            capture_rotation_start: 0,
+            last_capture_rotation: Instant::now(),
         }
     }
 
@@ -300,6 +308,12 @@ impl<'a> App<'a> {
                 self.visible_objects = new_visible_objects;
                 self.update_capturing();
             }
+
+            // Runs every iteration (not just on visibility change) since
+            // rotation is time-driven, not scroll-driven. Cheap to call when
+            // there's nothing to do - an elapsed-time check and, usually, an
+            // early return.
+            self.rotate_capturing();
 
             if needs_render && pacer.is_time_to_render() {
                 needs_render = false;
@@ -351,6 +365,18 @@ impl<'a> App<'a> {
             && !self.visible_objects.contains(&object_id)
         {
             return;
+        }
+
+        // Hard cap on concurrent captures, enforced here (not just in the
+        // rotation logic) so it can never be transiently exceeded - e.g. by
+        // several nodes becoming capture-eligible at once before the next
+        // rotation tick has a chance to run.
+        if let Some(max) = self.config.max_concurrent_captures {
+            if self.capturing_objects.len() >= max
+                && !self.capturing_objects.contains(&object_id)
+            {
+                return;
+            }
         }
 
         let Some(node) = self.state.nodes.get(&object_id) else {
@@ -414,6 +440,81 @@ impl<'a> App<'a> {
             .collect();
         for object_id in need_to_stop {
             self.stop_capture(object_id);
+        }
+    }
+
+    /// How often to swap which nodes are actively captured when
+    /// max_concurrent_captures limits capture to fewer than are eligible.
+    /// Deliberately much slower than typical UI/render cadence - rotating on
+    /// every frame would create more PipeWire stream churn than not
+    /// rotating at all, defeating the purpose of capping concurrency in the
+    /// first place.
+    const CAPTURE_ROTATION_INTERVAL: Duration = Duration::from_secs(3);
+
+    /// If max_concurrent_captures is set and more objects are eligible for
+    /// capture than that, periodically swap which subset is actually being
+    /// captured so every eligible object eventually gets sampled instead of
+    /// whichever ones happened to become eligible first (and then stay
+    /// captured forever, starving everything else).
+    fn rotate_capturing(&mut self) {
+        let Some(max) = self.config.max_concurrent_captures else {
+            return;
+        };
+
+        if self.last_capture_rotation.elapsed()
+            < Self::CAPTURE_ROTATION_INTERVAL
+        {
+            return;
+        }
+
+        // Same eligibility rule start_capture()/update_capturing() already
+        // use: scoped to on-screen objects under lazy_capture, otherwise
+        // every capturable object regardless of visibility.
+        let mut eligible: Vec<ObjectId> = if self.config.lazy_capture {
+            self.visible_objects
+                .intersection(&self.capturable_objects)
+                .copied()
+                .collect()
+        } else {
+            self.capturable_objects.iter().copied().collect()
+        };
+
+        if eligible.len() <= max {
+            // Everything eligible already fits under the cap - nothing to
+            // rotate. Leave last_capture_rotation alone so a rotation isn't
+            // "owed" the moment the eligible set grows past max again.
+            return;
+        }
+
+        self.last_capture_rotation = Instant::now();
+
+        // Sorting gives a stable, deterministic rotation order across ticks
+        // (HashSet iteration order isn't stable) so each tick advances
+        // through the *same* sequence rather than picking an arbitrary new
+        // subset every time.
+        eligible.sort_unstable();
+
+        let n = eligible.len();
+        let start = self.capture_rotation_start % n;
+        let window: HashSet<ObjectId> =
+            (0..max.min(n)).map(|i| eligible[(start + i) % n]).collect();
+        self.capture_rotation_start = (start + max) % n;
+
+        let need_to_stop: Vec<_> = self
+            .capturing_objects
+            .difference(&window)
+            .copied()
+            .collect();
+        for object_id in need_to_stop {
+            self.stop_capture(object_id);
+        }
+
+        let need_to_start: Vec<_> = window
+            .difference(&self.capturing_objects)
+            .copied()
+            .collect();
+        for object_id in need_to_start {
+            self.start_capture(object_id);
         }
     }
 
@@ -882,6 +983,7 @@ mod tests {
             tabs: vec![TabKind::Playback],
             lazy_capture: Default::default(),
             filters: Default::default(),
+            max_concurrent_captures: Default::default(),
         };
 
         let mut app = App::new(wirehose, event_rx, config);
@@ -983,6 +1085,7 @@ mod tests {
             ],
             lazy_capture: Default::default(),
             filters: Default::default(),
+            max_concurrent_captures: Default::default(),
         };
         let mut app = App::new(&wirehose, event_rx, config);
 
@@ -1270,5 +1373,112 @@ mod tests {
             commands.borrow_mut().pop_front(),
             Some(mock::MockCommand::NodeCaptureStop(id))
         );
+    }
+
+    /// Back-dates last_capture_rotation so the next rotate_capturing() call
+    /// doesn't have to wait out the real interval.
+    fn force_rotation_due(app: &mut App<'_>) {
+        app.last_capture_rotation = std::time::Instant::now()
+            .checked_sub(App::CAPTURE_ROTATION_INTERVAL * 2)
+            .unwrap();
+    }
+
+    #[test]
+    fn start_capture_enforces_max_concurrent() {
+        let commands = RefCell::new(VecDeque::new());
+        let wirehose = mock::WirehoseHandle::with_commands(&commands);
+        let (_, event_rx) = mpsc::channel();
+        let config = Config::from_toml_str(
+            "lazy_capture = false\nmax_concurrent_captures = 2",
+        );
+        let mut app = App::new(&wirehose, event_rx, config);
+
+        for i in 1..=3 {
+            let id = ObjectId::from_raw_id(i);
+            add_capturable_node(&mut app, id);
+            app.set_capture_eligibility(CaptureEligibility::Eligible(id));
+        }
+
+        // Only 2 of the 3 eligible nodes should actually be capturing.
+        assert_eq!(app.capturing_objects.len(), 2);
+    }
+
+    #[test]
+    fn rotate_capturing_respects_max() {
+        let commands = RefCell::new(VecDeque::new());
+        let wirehose = mock::WirehoseHandle::with_commands(&commands);
+        let (_, event_rx) = mpsc::channel();
+        let config = Config::from_toml_str(
+            "lazy_capture = true\nmax_concurrent_captures = 2",
+        );
+        let mut app = App::new(&wirehose, event_rx, config);
+
+        for i in 1..=5 {
+            let id = ObjectId::from_raw_id(i);
+            add_capturable_node(&mut app, id);
+            app.capturable_objects.insert(id);
+            app.visible_objects.insert(id);
+        }
+
+        force_rotation_due(&mut app);
+        app.rotate_capturing();
+
+        assert_eq!(app.capturing_objects.len(), 2);
+    }
+
+    #[test]
+    fn rotate_capturing_advances_window() {
+        let commands = RefCell::new(VecDeque::new());
+        let wirehose = mock::WirehoseHandle::with_commands(&commands);
+        let (_, event_rx) = mpsc::channel();
+        let config = Config::from_toml_str(
+            "lazy_capture = true\nmax_concurrent_captures = 2",
+        );
+        let mut app = App::new(&wirehose, event_rx, config);
+
+        for i in 1..=5 {
+            let id = ObjectId::from_raw_id(i);
+            add_capturable_node(&mut app, id);
+            app.capturable_objects.insert(id);
+            app.visible_objects.insert(id);
+        }
+
+        force_rotation_due(&mut app);
+        app.rotate_capturing();
+        let first_window = app.capturing_objects.clone();
+
+        force_rotation_due(&mut app);
+        app.rotate_capturing();
+        let second_window = app.capturing_objects.clone();
+
+        assert_eq!(first_window.len(), 2);
+        assert_eq!(second_window.len(), 2);
+        assert_ne!(first_window, second_window);
+    }
+
+    #[test]
+    fn rotate_capturing_noop_under_cap() {
+        let commands = RefCell::new(VecDeque::new());
+        let wirehose = mock::WirehoseHandle::with_commands(&commands);
+        let (_, event_rx) = mpsc::channel();
+        let config = Config::from_toml_str(
+            "lazy_capture = true\nmax_concurrent_captures = 10",
+        );
+        let mut app = App::new(&wirehose, event_rx, config);
+
+        for i in 1..=3 {
+            let id = ObjectId::from_raw_id(i);
+            add_capturable_node(&mut app, id);
+            app.capturable_objects.insert(id);
+            app.visible_objects.insert(id);
+            app.set_capture_eligibility(CaptureEligibility::Eligible(id));
+        }
+
+        force_rotation_due(&mut app);
+        app.rotate_capturing();
+
+        // Fewer eligible nodes than the cap - everything stays captured,
+        // nothing gets rotated out.
+        assert_eq!(app.capturing_objects.len(), 3);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ pub struct Config {
     pub tab: usize,
     pub tabs: Vec<TabKind>,
     pub lazy_capture: bool,
+    pub max_concurrent_captures: Option<usize>,
     pub filters: Vec<MatchCondition>,
 }
 
@@ -88,6 +89,7 @@ struct ConfigFile {
     tabs: Vec<TabKind>,
     #[serde(default = "default_lazy_capture")]
     lazy_capture: bool,
+    max_concurrent_captures: Option<usize>,
     #[serde(default = "Filter::defaults", deserialize_with = "Filter::merge")]
     filters: Vec<Filter>,
 }
@@ -328,6 +330,10 @@ impl ConfigFile {
         if opt.lazy_capture {
             self.lazy_capture = true;
         }
+
+        if let Some(max_concurrent_captures) = &opt.max_concurrent_captures {
+            self.max_concurrent_captures = Some(*max_concurrent_captures);
+        }
     }
 }
 
@@ -396,6 +402,7 @@ impl TryFrom<ConfigFile> for Config {
             tab,
             tabs: config_file.tabs,
             lazy_capture: config_file.lazy_capture,
+            max_concurrent_captures: config_file.max_concurrent_captures,
             filters,
         })
     }
@@ -481,6 +488,7 @@ pub mod strict {
         tab: Option<TabKind>,
         tabs: Vec<TabKind>,
         lazy_capture: bool,
+        max_concurrent_captures: Option<usize>,
         filters: Vec<Filter>,
     }
 
@@ -502,6 +510,7 @@ pub mod strict {
                 tab: strict.tab,
                 tabs: strict.tabs,
                 lazy_capture: strict.lazy_capture,
+                max_concurrent_captures: strict.max_concurrent_captures,
                 filters: strict.filters,
             }
         }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -78,6 +78,14 @@ pub struct Opt {
     #[clap(long, conflicts_with = "no_lazy_capture")]
     pub lazy_capture: bool,
 
+    /// Cap how many nodes have their peak levels actively monitored at once,
+    /// rotating which ones are captured every few seconds if more than this
+    /// many are eligible (further reduces CPU usage on systems with many
+    /// concurrent streams/devices, at the cost of meters updating less often
+    /// per node)
+    #[clap(long, value_name = "COUNT")]
+    pub max_concurrent_captures: Option<usize>,
+
     #[cfg(debug_assertions)]
     #[clap(short, long)]
     pub dump_events: bool,

--- a/wiremix.toml
+++ b/wiremix.toml
@@ -44,6 +44,18 @@ enforce_max_volume = false
 # If true, only monitor peak levels of visible nodes
 lazy_capture = false
 
+# Cap how many nodes have their peak levels actively monitored at once. If
+# more nodes than this are eligible for capture (all visible nodes under
+# lazy_capture, or every capturable node otherwise), which ones are actually
+# captured rotates every few seconds so each eventually gets sampled, rather
+# than whichever nodes happened to become eligible first holding their slot
+# indefinitely. Meters for nodes not currently in the active set keep
+# showing their last captured value until their next turn. Unset by default
+# (no cap) - each additional concurrent capture is a real PipeWire stream
+# the session manager has to track, so on a system with many concurrent
+# streams/devices this is the most direct way to bound that cost.
+#max_concurrent_captures = 8
+
 
 # Keybindings
 #


### PR DESCRIPTION
⚠️ **Full Disclosure:** Drafted with AI assistance (Claude); reviewed by me briefly. I am neither a Rust developer nor pipewire expert. If I should stop making these PRs into your wonderful project, please let me know. ⚠️

That being said, I hope these can be helpful and useful additions that users could appreciate.

---

Each node wiremix monitors for peak levels gets its own dedicated PipeWire capture stream (`wirehose/stream.rs::capture_node`). Every one of those is a real client object the session manager has to track and policy-link, and that cost scales with how many exist at once - not with anything CPU-throttleable, since it's driven by stream count, not per-quantum processing. `lazy_capture` already limits this to on-screen nodes, but on views where many nodes are visible simultaneously (a busy Output Devices tab, a tall terminal), that alone doesn't bound the concurrent stream count.

Adds `max_concurrent_captures: Option<usize>` (unset = current unbounded behavior):

- When set and more nodes are eligible for capture than the cap allows, which ones are actually captured rotates on a fixed 3s interval (deliberately much slower than render cadence - rotating every frame would create more stream churn than not capping at all) so every eligible node eventually gets sampled rather than whichever ones happened to become eligible first holding their slot indefinitely.
- Meters for nodes outside the active window keep showing their last captured value until their next turn, rather than resetting to zero.
- The cap is enforced as a hard invariant directly in `start_capture()` (not just in the rotation logic), so it can never be transiently exceeded even if several nodes become eligible at once before the next rotation tick runs.

**New config key** (optional, no-op when unset):

```toml
# Cap how many nodes have their peak levels actively monitored at once.
# Rotates which ones every few seconds if more are eligible than this.
max_concurrent_captures = 8
```

Also available as `--max-concurrent-captures <COUNT>` on the command line.

**Verified live against the real PipeWire graph**, not just unit tests: with `--max-concurrent-captures 2`, `pw-dump` showed exactly 2 `wiremix-capture` streams at any moment, and the actual target node IDs fully changed after the 3s interval elapsed - confirming both the cap and the rotation are real, not just passing in isolation.

**Tested:**
- `cargo test`: 148/148 passing, including 4 new tests covering the cap being enforced by `start_capture`, rotation respecting the cap, the active window actually advancing between rotations, and the no-op case where fewer nodes are eligible than the cap
- `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo doc` (matching this repo's CI): all clean

---
*Drafted with AI assistance (Claude); reviewed by me before opening. Left as a draft while I finish going through it - not requesting review yet.*

---

This feature, together with other experimental changes, is included and should be ready to play with in the [wiremix-extras](https://github.com/HoneyHazard/wiremix-extras) experiment.
